### PR TITLE
add new /refresh route

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,15 @@ The following routes are exposed by the worker:
     -   **Description:** Initiates the Google OAuth login flow. It will redirect the user to the Google consent screen.
     -   **`redirect_to` (optional):** The URL to redirect the user back to after a successful login. If not provided, it defaults to the first origin in the app's `allowed_origins` config. The origin of this URL must be in the `allowed_origins` list.
 
+-   `GET /auth/:app_id/me`
+    -   **Description:** Returns the authenticated user's Google profile information (name, email, picture) as a JSON object. Requires a valid session cookie.
+
+-   `GET /auth/:app_id/refresh`
+    -   **Description:** Refreshes the user's access token using the stored refresh token. This route updates the session and extends the session cookies.
+
 -   `GET /auth/:app_id/logout?redirect_to=<URL>`
     -   **Description:** Logs the user out by clearing their session data and cookies.
     -   **`redirect_to` (optional):** A URL to redirect the user to after logout is complete.
-
--   `GET /auth/:app_id/me`
-    -   **Description:** Returns the authenticated user's Google profile information (name, email, picture) as a JSON object. Requires a valid session cookie.
 
 -   `ALL /auth/:app_id/api/*`
     -   **Description:** Acts as an authenticated proxy. It forwards any request (`GET`, `POST`, etc.) to the `gas_url` configured for the `:app_id`. It automatically injects the user's `access_token` into the proxied request and handles token refresh if necessary.

--- a/src/index.ts
+++ b/src/index.ts
@@ -402,22 +402,31 @@ router.all("/auth/:app_id/api/*", async (request: IRequest, env: Env) => {
         newHeaders.set("Access-Control-Allow-Origin", origin);
         newHeaders.set("Access-Control-Allow-Credentials", "true");
 
-        if (needsCookieUpdate) { // Conditionally append cookies
-            const updatedSessionCookie = cookie.serialize("session_id", sessionId, {
-                httpOnly: true,
-                secure: true,
-                sameSite: "lax",
-                domain: "josephtseng-tw.com",
-                path: "/",
-                maxAge: 7 * 24 * 60 * 60, // 7 days
-            });
-            const updatedLoggedInCookie = cookie.serialize("is_logged_in", "true", {
-                secure: true,
-                sameSite: "lax",
-                domain: "josephtseng-tw.com",
-                path: "/",
-                maxAge: 7 * 24 * 60 * 60, // 7 days
-            });
+        if (needsCookieUpdate) {
+            // Conditionally append cookies
+            const updatedSessionCookie = cookie.serialize(
+                "session_id",
+                sessionId,
+                {
+                    httpOnly: true,
+                    secure: true,
+                    sameSite: "lax",
+                    domain: "josephtseng-tw.com",
+                    path: "/",
+                    maxAge: 7 * 24 * 60 * 60, // 7 days
+                },
+            );
+            const updatedLoggedInCookie = cookie.serialize(
+                "is_logged_in",
+                "true",
+                {
+                    secure: true,
+                    sameSite: "lax",
+                    domain: "josephtseng-tw.com",
+                    path: "/",
+                    maxAge: 7 * 24 * 60 * 60, // 7 days
+                },
+            );
             newHeaders.append("Set-Cookie", updatedSessionCookie);
             newHeaders.append("Set-Cookie", updatedLoggedInCookie);
         }
@@ -556,7 +565,8 @@ router.get("/auth/:app_id/me", async (request: IRequest, env: Env) => {
         "Access-Control-Allow-Credentials": "true",
     });
 
-    if (needsCookieUpdate) { // Conditionally append cookies
+    if (needsCookieUpdate) {
+        // Conditionally append cookies
         const updatedSessionCookie = cookie.serialize("session_id", sessionId, {
             httpOnly: true,
             secure: true,
@@ -576,6 +586,156 @@ router.get("/auth/:app_id/me", async (request: IRequest, env: Env) => {
         headers.append("Set-Cookie", updatedLoggedInCookie);
     }
     return new Response(JSON.stringify(userInfo), { headers });
+});
+
+// GET /auth/:app_id/refresh
+router.get("/auth/:app_id/refresh", async (request: IRequest, env: Env) => {
+    const { app_id } = request.params;
+    const origin = request.headers.get("Origin");
+
+    const config: AppConfig | null = await env.TOKEN_STORE.get(
+        `config:${app_id}`,
+        "json",
+    );
+
+    const createCorsError = (message: string, status: number) => {
+        const headers = new Headers();
+        if (origin && config?.allowed_origins.includes(origin)) {
+            headers.set("Access-Control-Allow-Origin", origin);
+            headers.set("Access-Control-Allow-Credentials", "true");
+        } else if (origin) {
+            headers.set("Access-Control-Allow-Origin", origin);
+            headers.set("Access-Control-Allow-Credentials", "true");
+        }
+        return new Response(message, { status, headers });
+    };
+
+    if (!config) {
+        return createCorsError("App not found", 404);
+    }
+    if (!origin || !config.allowed_origins.includes(origin)) {
+        return createCorsError("Invalid origin", 403);
+    }
+
+    const cookies = cookie.parse(request.headers.get("Cookie") || "");
+    const sessionId = cookies.session_id;
+
+    if (!sessionId) {
+        return createCorsError("Not authenticated", 401);
+    }
+
+    const session: Session | null = await env.TOKEN_STORE.get(
+        `session:${sessionId}`,
+        "json",
+    );
+
+    if (!session || !session.refresh_token) {
+        // If no session or no refresh token, we can't refresh.
+        // This session is not useful anymore.
+        const errorResponse = createCorsError(
+            "Invalid session or no refresh token",
+            401,
+        );
+        const sessionCookie = cookie.serialize("session_id", "", {
+            httpOnly: true,
+            secure: true,
+            sameSite: "lax",
+            domain: "josephtseng-tw.com",
+            path: "/",
+            expires: new Date(0),
+        });
+        const loggedInCookie = cookie.serialize("is_logged_in", "", {
+            secure: true,
+            sameSite: "lax",
+            domain: "josephtseng-tw.com",
+            path: "/",
+            expires: new Date(0),
+        });
+        errorResponse.headers.append("Set-Cookie", sessionCookie);
+        errorResponse.headers.append("Set-Cookie", loggedInCookie);
+        if (sessionId) {
+            await env.TOKEN_STORE.delete(`session:${sessionId}`);
+        }
+        return errorResponse;
+    }
+
+    const refreshResponse = await fetch("https://oauth2.googleapis.com/token", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: new URLSearchParams({
+            client_id: env.GOOGLE_CLIENT_ID,
+            client_secret: env.GOOGLE_CLIENT_SECRET,
+            refresh_token: session.refresh_token,
+            grant_type: "refresh_token",
+        }),
+    });
+
+    const refreshData: any = await refreshResponse.json();
+
+    if (refreshData.access_token) {
+        session.access_token = refreshData.access_token;
+        // Google might return a new refresh token (rare, but possible)
+        if (refreshData.refresh_token) {
+            session.refresh_token = refreshData.refresh_token;
+        }
+        await env.TOKEN_STORE.put(
+            `session:${sessionId}`,
+            JSON.stringify(session),
+            {
+                expirationTtl: 30 * 24 * 60 * 60, // 30 days
+            },
+        );
+
+        const headers = new Headers({
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": origin,
+            "Access-Control-Allow-Credentials": "true",
+        });
+
+        const updatedSessionCookie = cookie.serialize("session_id", sessionId, {
+            httpOnly: true,
+            secure: true,
+            sameSite: "lax",
+            domain: "josephtseng-tw.com",
+            path: "/",
+            maxAge: 7 * 24 * 60 * 60, // 7 days
+        });
+        const updatedLoggedInCookie = cookie.serialize("is_logged_in", "true", {
+            secure: true,
+            sameSite: "lax",
+            domain: "josephtseng-tw.com",
+            path: "/",
+            maxAge: 7 * 24 * 60 * 60, // 7 days
+        });
+        headers.append("Set-Cookie", updatedSessionCookie);
+        headers.append("Set-Cookie", updatedLoggedInCookie);
+
+        return new Response(JSON.stringify({ success: true }), { headers });
+    } else {
+        // Refresh token is likely invalid or revoked.
+        const errorResponse = createCorsError("Session expired", 401);
+        const sessionCookie = cookie.serialize("session_id", "", {
+            httpOnly: true,
+            secure: true,
+            sameSite: "lax",
+            domain: "josephtseng-tw.com",
+            path: "/",
+            expires: new Date(0),
+        });
+        const loggedInCookie = cookie.serialize("is_logged_in", "", {
+            secure: true,
+            sameSite: "lax",
+            domain: "josephtseng-tw.com",
+            path: "/",
+            expires: new Date(0),
+        });
+        errorResponse.headers.append("Set-Cookie", sessionCookie);
+        errorResponse.headers.append("Set-Cookie", loggedInCookie);
+        await env.TOKEN_STORE.delete(`session:${sessionId}`);
+        return errorResponse;
+    }
 });
 
 // GET /auth/:app_id/logout


### PR DESCRIPTION
## Description
The newly added route, GET `/auth/:app_id/refresh`, is designed to refresh a user's access token without requiring them to go through the full OAuth login flow
  again.

  Here's a breakdown of what it does:

   1. Authentication Check:
       * It retrieves the `session_id` from the user's cookies.
       * It uses this `session_id` to fetch the stored session data, which includes the `refresh_token`.
       * If no valid session or `refresh_token` is found, it returns a **401 Unauthorized error** and clears the session-related cookies, effectively logging the user out.

   2. Token Refresh:
       * If a valid session and `refresh_token` are present, it makes a **POST** request to Google's OAuth 2.0 token endpoint (https://oauth2.googleapis.com/token).
       * This request sends the `refresh_token` along with `client_id`, `client_secret`, and `grant_type='refresh_token'`.

   3. Session Update:
       * If Google successfully returns a new `access_token` (and potentially a new `refresh_token`, though this is rare), the route updates the user's session data in the `TOKEN_STORE` with these new tokens.
       * The session's expiration time is also reset to 30 days.

   4. Cookie Refresh:
       * It updates the `session_id` and `is_logged_in` cookies, extending their `maxAge` to 7 days, ensuring the user remains logged in from the client-side perspective.

   5. Response:
       * On successful token refresh, it returns a **200 OK** response with `{"success": true}` and includes the updated cookies in the response headers.
       * If the refresh fails (e.g., Google reports the refresh token is invalid), it returns a **401 Unauthorized error**, deletes the session from storage, and clears the client-side cookies.

  In essence, this route provides a mechanism for your frontend to silently obtain a fresh `access_token` when the current one expires, improving the user experience by avoiding repeated logins.

Note:
> the frontend cannot use the refresh route directly if it hasn't completed the full OAuth login flow first.

  Here's why:

   1. Session Dependency: `The /auth/:app_id/refresh` route relies on the presence of a `session_id` cookie sent from the frontend. This `session_id` is used to retrieve the stored session data, which contains the `refresh_token`.
   2. Session Creation: The `session_id` cookie and the corresponding session data (including the `refresh_token`) are created and set only after the successful completion of the full OAuth login flow, specifically when the `/auth/:app_id/callback` route is processed.

  Without a valid `session_id` cookie established through the initial login process, the refresh route will return a "Not authenticated" (401) error.